### PR TITLE
Release/swiftui/1.0.4 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## New Interfaces 
-- Added `GlobalOptions.enableViewAdaptorAutoReset`
-  - This option decides  whether to reset customized view adaptors whenever SendbirdSwiftUI View's `onDisappear` is called.
-  - Set this flag to `false` before a specific SendbirdSwiftUI View appears, if you want to prevent its customized views from resetting, even after its `onDisappear` is called.
+## Notices
+- If you are having trouble building SendbirdSwiftUI for versions `1.0.2`, `1.0.3`, please update to `1.0.4` or above.
+- SendbirdSwiftUI is no longer updated for Cocoapods, due to [Cocoapods' deprecation plans](https://blog.cocoapods.org/CocoaPods-Support-Plans/).
+    - You can still use SendbirdSwiftUI for Cocoapods for versions `1.0.1` or below.
 
-## Improvements
-- Fixed customized SendbirdSwiftUI View's customized styles being reset whenever a SendbirdSwiftUI View 's `onDisappear` is called (e.g., when coming back from another `TabView`)
+
+## Improvements 
+- Fixed the below build failures for SendbirdSwiftUI versions `1.0.2`, `1.0.3`.
+    - `Failed to build module 'SendbirdSwiftUI'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 5.10 (swiftlang-5.10.0.13 clang-1500.3.9.4)', while this compiler is 'Apple Swift version 6.0.3 effective-5.10 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)'). Please select a toolchain which matches the SDK.`

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdSwiftUI",
-            url: "https://github.com/sendbird/sendbird-swiftui-ios/releases/download/1.0.3/SendbirdSwiftUI.xcframework.zip", // SendbirdSwiftUI_URL
-            checksum: "4599d0209a95045c1aee95fb9d90d7caeb6df284d2e9810a057aa6a893ac0120" // SendbirdSwiftUI_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-swiftui-ios/releases/download/1.0.4/SendbirdSwiftUI.xcframework.zip", // SendbirdSwiftUI_URL
+            checksum: "f24e8527cbb20c193c1c24b0994c34a3b3ea8b79c824ebf8e2b85d48e09b1007" // SendbirdSwiftUI_CHECKSUM
             
         ),
         .binaryTarget(

--- a/Sample/QuickStartSwiftUI.xcodeproj/project.pbxproj
+++ b/Sample/QuickStartSwiftUI.xcodeproj/project.pbxproj
@@ -7615,7 +7615,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7647,7 +7647,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample.SwiftUINotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7737,7 +7737,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7824,7 +7824,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample.SwiftUINotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Sample/project.yml
+++ b/Sample/project.yml
@@ -43,7 +43,7 @@ settingGroups:
     FRAMEWORK_SEARCH_PATHS: ''
     IPHONEOS_DEPLOYMENT_TARGET: '15.0'
     LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
-    MARKETING_VERSION: '1.0.3'
+    MARKETING_VERSION: '1.0.4'
     PRODUCT_NAME: "$(TARGET_NAME)"
     SDKROOT: iphoneos
     SWIFT_VERSION: '5.0'


### PR DESCRIPTION
## Notices
- If you are having trouble building SendbirdSwiftUI for versions `1.0.2`, `1.0.3`, please update to `1.0.4` or above.
- SendbirdSwiftUI is no longer updated for Cocoapods, due to [Cocoapods' deprecation plans](https://blog.cocoapods.org/CocoaPods-Support-Plans/).
    - You can still use SendbirdSwiftUI for Cocoapods for versions `1.0.1` or below.


## Improvements 
- Fixed the below build failures for SendbirdSwiftUI versions `1.0.2`, `1.0.3`.
    - `Failed to build module 'SendbirdSwiftUI'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 5.10 (swiftlang-5.10.0.13 clang-1500.3.9.4)', while this compiler is 'Apple Swift version 6.0.3 effective-5.10 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)'). Please select a toolchain which matches the SDK.`