### PR TITLE
Release/swiftui/1.1.2 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-## Improvements
-- Updated the SDK build base to Xcode 16.4.
+## New Interfaces
+- Use `GlobalOptions.hidesSharedBackgroundForCustomNavBarButton` to hide or show the default liquid glass effect from customized SendbirdSwiftUI navigation bar buttons in iOS 26 or above.
+  - Set this flag to `true` to hide it.
+
+## Improvements 
+- Updated **SendbirdSwiftUI** to be built with Xcode 26.0.
 
 ## ⚠️ Compatibility Notice
+**SendbirdSwiftUI** v1.1.1 or earlier is not compatible with **SendbirdChatSDK** v4.32.0 or higher.
+Please use **SendbirdChatSDK** <= 4.30.0 with **SendbirdSwiftUI** <= v1.1.1.
 
-**SendbirdSwiftUI v1.1.0 and earlier are not compatible with SendbirdChatSDK v4.28.1 or higher.**  
-Please use `SendbirdChatSDK ≤ 4.28.0` with SendbirdSwiftUI versions **up to v1.1.0**.
+To use **SendbirdChatSDK** ≥ 4.32.0, please update **SendbirdSwiftUI** to v1.1.2 or later.
 
-To use `SendbirdChatSDK ≥ 4.28.1`, please upgrade to `SendbirdSwiftUI v1.1.1` or later, which is built with Xcode 16.4.

--- a/Package.swift
+++ b/Package.swift
@@ -16,18 +16,18 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/sendbird/sendbird-chat-sdk-ios",
-            from: "4.29.0"
+            from: "4.32.0"
         ),
         .package(
             url: "https://github.com/sendbird/sendbird-uikit-ios-spm",
-            from: "3.32.2"
+            from: "3.32.3"
         ),
     ],
     targets: [
         .binaryTarget(
             name: "SendbirdSwiftUI",
-            url: "https://github.com/sendbird/sendbird-swiftui-ios/releases/download/1.1.1/SendbirdSwiftUI.xcframework.zip", // SendbirdSwiftUI_URL
-            checksum: "cc2815f523db320c30092e97a48bf0575496742f5a074130d5bf4dbc7f4e4d80" // SendbirdSwiftUI_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-swiftui-ios/releases/download/1.1.2/SendbirdSwiftUI.xcframework.zip", // SendbirdSwiftUI_URL
+            checksum: "91c877b1b9e66e8d456a4b461ab52b3a7f6a0b7959c02fc183dd3d0c4c5d2199" // SendbirdSwiftUI_CHECKSUM
         ),
         .target(
             name: "SendbirdSwiftUITarget",

--- a/Sample/QuickStartSwiftUI.xcodeproj/project.pbxproj
+++ b/Sample/QuickStartSwiftUI.xcodeproj/project.pbxproj
@@ -7647,7 +7647,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7679,7 +7679,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample.SwiftUINotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7769,7 +7769,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7856,7 +7856,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample.SwiftUINotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7905,7 +7905,7 @@
 			repositoryURL = "https://github.com/sendbird/sendbird-chat-sdk-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.29.0;
+				minimumVersion = 4.32.0;
 			};
 		};
 		BA2412B4C520C201A8099145 /* XCRemoteSwiftPackageReference "sendbird-uikit-ios-spm" */ = {
@@ -7913,7 +7913,7 @@
 			repositoryURL = "https://github.com/sendbird/sendbird-uikit-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.32.2;
+				minimumVersion = 3.32.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Sample/QuickStartSwiftUI/CustomSample/CustomViews/GroupChannelList/ViewConverter/Header/CustomGroupChannelList.ViewConverter.Header.rightView.swift
+++ b/Sample/QuickStartSwiftUI/CustomSample/CustomViews/GroupChannelList/ViewConverter/Header/CustomGroupChannelList.ViewConverter.Header.rightView.swift
@@ -25,6 +25,9 @@ extension CustomGroupChannelList.ViewConverter.Header {
                     .rightView { config in
                         Text("Right \(customFlag ? "ON" : "OFF")")
                             .foregroundStyle(.blue)
+                        
+                        // This removes the right bar button.
+                        // Color.clear.frame(width: 0, height: 0)
                     }
                 }
             )

--- a/Sample/QuickStartSwiftUI/LoginView.swift
+++ b/Sample/QuickStartSwiftUI/LoginView.swift
@@ -142,6 +142,11 @@ extension LoginView {
         SendbirdUI.config.groupChannel.channel.isMultipleFilesMessageEnabled = true
         
         SBUGlobals.isImageCompressionEnabled = true
+        
+        // Set `hidesSharedBackgroundForUIBarButtonItem` to `true` to remove liquid glass effect from custom navigation bar button.
+        if #available(iOS 26.0, *) {
+            GlobalOptions.hidesSharedBackgroundForCustomNavBarButton = true
+        }
     }
     
     func initializeSendbird() {

--- a/Sample/project.yml
+++ b/Sample/project.yml
@@ -12,10 +12,10 @@ options:
 packages:
   SendbirdChatSDK:
     url: https://github.com/sendbird/sendbird-chat-sdk-ios
-    from: 4.29.0
+    from: 4.32.0
   SendbirdUIKit:
     url: https://github.com/sendbird/sendbird-uikit-ios-spm
-    from: 3.32.2
+    from: 3.32.3
     
 schemes:
   QuickStartSwiftUI:
@@ -43,7 +43,7 @@ settingGroups:
     FRAMEWORK_SEARCH_PATHS: ''
     IPHONEOS_DEPLOYMENT_TARGET: '15.0'
     LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
-    MARKETING_VERSION: '1.1.1'
+    MARKETING_VERSION: '1.1.2'
     PRODUCT_NAME: "$(TARGET_NAME)"
     SDKROOT: iphoneos
     SWIFT_VERSION: '5.0'

--- a/Sources/SwiftUI/Common/GlobalOptions.swift
+++ b/Sources/SwiftUI/Common/GlobalOptions.swift
@@ -15,4 +15,17 @@ public class GlobalOptions {
     /// Set to `true` by default.
     /// - Since: 1.0.3
     public static var enableViewAdaptorAutoReset = true
+    
+    /// Setting this flag to `true` removes the default liquid glass effect from custom SendbirdSwiftUI navigation bar buttons for iOS 26 or above.
+    /// Setting this flag to `false` shows the default liquid glass effect from custom SendbirdSwiftUI navigation bar buttons for iOS 26 or above.
+    /// The default is set to `false`.
+    ///
+    /// ```
+    /// GlobalOptions.hidesSharedBackgroundForUIBarButtonItem = false // shows liquid glass effect on custom SendbirdSwiftUI navigation bar buttons.
+    /// GlobalOptions.hidesSharedBackgroundForUIBarButtonItem = true // removes liquid glass effect from custom SendbirdSwiftUI navigation bar buttons.
+    /// ```
+    ///
+    /// - Since: [SWIFTUI_NEXT_VERSION]
+    @available(iOS 26, *)
+    public static var hidesSharedBackgroundForCustomNavBarButton: Bool = false
 }

--- a/Sources/SwiftUI/Util/WrapperUIViews.swift
+++ b/Sources/SwiftUI/Util/WrapperUIViews.swift
@@ -49,6 +49,13 @@ class SwiftUIBarButtonItem: UIBarButtonItem {
         }
         
         self.customView = containerView
+        
+        // Remove default liquid glass effect from custom navigation bar button
+        if #available(iOS 26.0, *) {
+            if GlobalOptions.hidesSharedBackgroundForCustomNavBarButton {
+                self.hidesSharedBackground = true
+            }
+        }
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## New Interfaces
- Use `GlobalOptions.hidesSharedBackgroundForCustomNavBarButton` to hide or show the default liquid glass effect from customized SendbirdSwiftUI navigation bar buttons in iOS 26 or above.
  - Set this flag to `true` to hide it.

## Improvements 
- Updated **SendbirdSwiftUI** to be built with Xcode 26.0.

## ⚠️ Compatibility Notice
**SendbirdSwiftUI** v1.1.1 or earlier is not compatible with **SendbirdChatSDK** v4.32.0 or higher.
Please use **SendbirdChatSDK** <= 4.30.0 with **SendbirdSwiftUI** <= v1.1.1.

To use **SendbirdChatSDK** ≥ 4.32.0, please update **SendbirdSwiftUI** to v1.1.2 or later.