### PR TITLE
Release/swiftui/1.2.2 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## Improvements
+
+- Fixed intermittent vertical gaps between message cells when custom SwiftUI message views are used on iOS 26
+- Fixed an empty navigation bar remaining above the header when the SDK pushes a channel view created by the `groupChannelView` builder
+
 ## Changes
 
-- Updated dependency SDK versions to the latest stable releases
-    - SendbirdChatSDK: 4.39.6
-    - SendbirdMessageTemplate: 3.35.4
+- Updated dependency SDK version to the latest stable release
+    - SendbirdMessageTemplate: 3.35.5

--- a/Package.swift
+++ b/Package.swift
@@ -20,14 +20,14 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/sendbird/sendbird-uikit-ios-spm",
-            from: "3.35.4"
+            from: "3.35.5"
         ),
     ],
     targets: [
         .binaryTarget(
             name: "SendbirdSwiftUI",
-            url: "https://github.com/sendbird/sendbird-swiftui-ios/releases/download/1.2.1/SendbirdSwiftUI.xcframework.zip", // SendbirdSwiftUI_URL
-            checksum: "c7ba4f817dab57e145436070b3932b83ae6ab3d54169f02276abe185f521f9ad" // SendbirdSwiftUI_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-swiftui-ios/releases/download/1.2.2/SendbirdSwiftUI.xcframework.zip", // SendbirdSwiftUI_URL
+            checksum: "46849c1c81a03fadf6151f8239310f8da36598f74cc2071fc8c85fd8b51f6bdb" // SendbirdSwiftUI_CHECKSUM
         ),
         .target(
             name: "SendbirdSwiftUITarget",

--- a/Sample/QuickStartSwiftUI.xcodeproj/project.pbxproj
+++ b/Sample/QuickStartSwiftUI.xcodeproj/project.pbxproj
@@ -6482,8 +6482,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				5EAACFDFB9C5FD3854D3CAAD /* NotificationService */,
 				FBBDE7E02B66DB6B276A7B3C /* QuickStartSwiftUI */,
+				5EAACFDFB9C5FD3854D3CAAD /* NotificationService */,
 			);
 		};
 /* End PBXProject section */
@@ -7631,7 +7631,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7663,7 +7663,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample.SwiftUINotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7753,7 +7753,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7840,7 +7840,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.swiftui.sample.SwiftUINotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -7897,7 +7897,7 @@
 			repositoryURL = "https://github.com/sendbird/sendbird-uikit-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.35.4;
+				minimumVersion = 3.35.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Sample/project.yml
+++ b/Sample/project.yml
@@ -15,7 +15,7 @@ packages:
     from: 4.39.6
   SendbirdUIKit:
     url: https://github.com/sendbird/sendbird-uikit-ios-spm
-    from: 3.35.4
+    from: 3.35.5
     
 schemes:
   QuickStartSwiftUI:
@@ -43,7 +43,7 @@ settingGroups:
     FRAMEWORK_SEARCH_PATHS: ''
     IPHONEOS_DEPLOYMENT_TARGET: '15.0'
     LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"]
-    MARKETING_VERSION: '1.2.1'
+    MARKETING_VERSION: '1.2.2'
     PRODUCT_NAME: "$(TARGET_NAME)"
     SDKROOT: iphoneos
     SWIFT_VERSION: '5.0'

--- a/Sources/SwiftUI/Protocol/ViewItemProtocol.swift
+++ b/Sources/SwiftUI/Protocol/ViewItemProtocol.swift
@@ -27,7 +27,20 @@ extension ViewItemProtocol {
         content: @escaping (Config) -> Content  // SwiftUI View
     ) -> ViewConverter<Config> {
         return ViewConverter { config in
-            let view = UIHostingController(rootView: content(config)).view
+            let hostingController = UIHostingController(rootView: content(config))
+            // SBISSUE-21868: On iOS 26, a detached hosting view (its controller is never added to
+            // the view controller hierarchy) starts receiving window-level safe-area insets and
+            // includes them in its intrinsicContentSize. Cell heights are measured while cells sit
+            // at/below the bottom screen edge during scrolling, so the inset (34pt home indicator,
+            // or more when laid out off-screen) gets baked into cached row heights, producing
+            // intermittent gaps/overlaps between cells. Hosted views are always embedded in
+            // UIKit-managed containers that already handle safe-area avoidance, so opting the
+            // hosted content out of all safe-area regions is safe and restores the iOS 18 behavior
+            // (where these views never received safe-area insets).
+            if #available(iOS 16.4, *) {
+                hostingController.safeAreaRegions = []
+            }
+            let view = hostingController.view
             view?.backgroundColor = .clear
             return view
         }

--- a/Sources/SwiftUI/Util/SwiftUIViewController.swift
+++ b/Sources/SwiftUI/Util/SwiftUIViewController.swift
@@ -25,20 +25,42 @@ struct SwiftUIViewController<Content: UIViewController> {
     private var injectionHandler: ((Content) -> Void)?
 }
 
+// MARK: - Environment
+
+/// Forces `SwiftUIViewController` to wrap its content in its own internal
+/// `UINavigationController` instead of consulting the global window hierarchy.
+///
+/// `findNavigationController()` walks the app's window/view-controller tree, so its
+/// result depends on transient global state (transition timing, OS version, embedding
+/// structure). When the SDK itself pushes a key function view wrapped in
+/// `SBUSwiftUIHostingController` (which hides the navigation bar), a "navigation
+/// controller found" result would route the header into that hidden bar and the header
+/// would disappear. SDK push call sites set this to `true` to make the outcome
+/// deterministic. (SBISSUE-21868)
+struct SBUAlwaysWrapNavigationKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var sbuAlwaysWrapNavigation: Bool {
+        get { self[SBUAlwaysWrapNavigationKey.self] }
+        set { self[SBUAlwaysWrapNavigationKey.self] = newValue }
+    }
+}
+
 // MARK: - UIViewControllerRepresentable
 extension SwiftUIViewController: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        if findNavigationController() {
+        if !context.environment.sbuAlwaysWrapNavigation, findNavigationController() {
             let newViewController: UIViewController = makeContent()
             return newViewController
         } else {
             let contentViewController = makeContent()
             let navigationController = UINavigationController(rootViewController: contentViewController)
-            
+
             navigationController.delegate = context.coordinator
             context.coordinator.parent = self
             context.coordinator.navigationController = navigationController
-            
             return navigationController
         }
     }

--- a/Sources/uikit/Extension/UINavigationController+SBUIKit.swift
+++ b/Sources/uikit/Extension/UINavigationController+SBUIKit.swift
@@ -44,3 +44,50 @@ extension UINavigationController {
     }
     #endif
 }
+
+#if SWIFTUI
+/// A hosting controller that hides the navigation bar while this screen is on
+/// screen. On entry it saves whether the bar was visible, then hides it; on exit
+/// it puts the bar back to that saved state (so the previous screen keeps its bar
+/// if it had one, and stays bar-less if it didn't).
+///
+/// SwiftUI key function views (e.g. `GroupChannelView`) render their header inside
+/// the content, not through `navigationItem`. When such a view is wrapped in a plain
+/// `UIHostingController` and pushed onto a `UINavigationController`, the navigation
+/// bar stays visible as an empty strip above the in-content header. (SBISSUE-21868)
+class SBUSwiftUIHostingController<Content: View>: UIHostingController<Content> {
+    /// The bar state to put back on exit, captured the first time this screen appears.
+    /// It is captured once and never re-read: a cancelled swipe-back gesture calls
+    /// `viewWillAppear` again while the bar is still hidden, so re-reading here would
+    /// save `true` and later "restore" the previous screen into a bar-less state.
+    private var wasNavigationBarHidden: Bool?
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let navigationController = self.navigationController {
+            if self.wasNavigationBarHidden == nil {
+                self.wasNavigationBarHidden = navigationController.isNavigationBarHidden
+            }
+            navigationController.setNavigationBarHidden(true, animated: animated)
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        guard let navigationController = self.navigationController,
+              let wasNavigationBarHidden = self.wasNavigationBarHidden else { return }
+
+        // Toggling the bar mid-flight leaves an interactive pop with a visible but
+        // empty bar, so wait for the gesture to settle. A cancelled gesture keeps
+        // this screen on top, so the bar must stay hidden.
+        if let coordinator = self.transitionCoordinator, coordinator.isInteractive {
+            coordinator.animate(alongsideTransition: nil) { context in
+                guard !context.isCancelled else { return }
+                navigationController.setNavigationBarHidden(wasNavigationBarHidden, animated: false)
+            }
+        } else {
+            navigationController.setNavigationBarHidden(wasNavigationBarHidden, animated: animated)
+        }
+    }
+}
+#endif

--- a/Sources/uikit/Module/Channel/GroupChannel/SBUGroupChannelModule.List.swift
+++ b/Sources/uikit/Module/Channel/GroupChannel/SBUGroupChannelModule.List.swift
@@ -1486,8 +1486,8 @@ extension SBUGroupChannelModule.List {
         with messageCell: SBUBaseMessageCell,
         indexPath: IndexPath
     ) {
-        messageCell.messageTemplateActionHandler = { [weak self, indexPath] action in
-            guard let self = self, let message = messageCell.message else { return }
+        messageCell.messageTemplateActionHandler = { [weak self, weak messageCell, indexPath] action in
+            guard let self = self, let message = messageCell?.message else { return }
             
             // Action Events
             switch action.type {

--- a/Sources/uikit/Module/Channel/SBUBaseChannelModule.Input.swift
+++ b/Sources/uikit/Module/Channel/SBUBaseChannelModule.Input.swift
@@ -282,7 +282,7 @@ extension SBUBaseChannelModule {
         }
         
         public func messageInputView(_ messageInputView: SBUMessageInputView, didSelectSend text: String) {
-            guard text.count > 0 else { return }
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             
             var parentMessage: BaseMessage?
             switch messageInputView.option {

--- a/Sources/uikit/Module/MessageThread/SBUMessageThreadModule.Input.swift
+++ b/Sources/uikit/Module/MessageThread/SBUMessageThreadModule.Input.swift
@@ -910,7 +910,7 @@ extension SBUMessageThreadModule {
                     parentMessage: self.parentMessage
                 )
             } else {
-                guard text.count > 0 else { return }
+                guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
                 messageInputView.setMode(.none)
                 
                 self.baseDelegate?.baseChannelModule(

--- a/Sources/uikit/View/Channel/MessageInput/SBUMessageInputView.swift
+++ b/Sources/uikit/View/Channel/MessageInput/SBUMessageInputView.swift
@@ -1313,7 +1313,7 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     open func onTapSendButton(_ sender: Any) {
         self.delegate?.messageInputView(
             self,
-            didSelectSend: self.textView?.text.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            didSelectSend: self.textView?.text ?? ""
         )
         self.endTypingMode()
         self.placeholderLabel.isHidden = !(self.textView?.text.isEmpty ?? true)
@@ -1336,16 +1336,18 @@ open class SBUMessageInputView: SBUView, SBUActionSheetDelegate, UITextViewDeleg
     
     @objc
     open func onTapSaveButton(_ sender: Any) {
-        let editedText = self.textView?.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let editedText = self.textView?.text ?? ""
+
+        // Empty guard mirrors the send-side check at SBUBaseChannelModule.Input.swift:285.
+        // Blocks whitespace-only edits from reaching Chat SDK without mutating payload. (CLNP-8711)
+        guard !editedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
         guard basedText != editedText else {
             self.endEditMode()
             self.delegate?.messageInputViewDidEndTyping()
             return
         }
-        self.delegate?.messageInputView(
-            self,
-            didSelectEdit: self.textView?.text.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        )
+        self.delegate?.messageInputView(self, didSelectEdit: editedText)
     }
     
     // MARK: - Internal methods

--- a/Sources/uikit/View/ChannelList/SBUGroupChannelListViewController.swift
+++ b/Sources/uikit/View/ChannelList/SBUGroupChannelListViewController.swift
@@ -246,7 +246,12 @@ open class SBUGroupChannelListViewController: SBUBaseChannelListViewController, 
                 #if SWIFTUI
                 if let groupChannelViewBuilder = self.groupChannelViewBuilder {
                     let view = groupChannelViewBuilder(channelURL, nil, messageListParams)
-                    let channelVC = UIHostingController(rootView: view)
+                    // `SBUSwiftUIHostingController` hides the navigation bar, so the key
+                    // function view must render its header in-content — force the internal
+                    // navigation controller path regardless of window state. (SBISSUE-21868)
+                    let channelVC = SBUSwiftUIHostingController(
+                        rootView: view.environment(\.sbuAlwaysWrapNavigation, true)
+                    )
                     self.navigationController?.pushViewControllerNonFlickering(channelVC, animated: true)
                     return
                 }

--- a/Sources/uikit/ViewModel/Channel/SBUBaseChannelViewModel.swift
+++ b/Sources/uikit/ViewModel/Channel/SBUBaseChannelViewModel.swift
@@ -253,7 +253,6 @@ open class SBUBaseChannelViewModel: SBUBaseViewModel {
     ///    - text: String value
     ///    - parentMessage: The parent message. The default value is `nil` when there's no parent message.
     open func sendUserMessage(text: String, parentMessage: BaseMessage? = nil) {
-        let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let messageParams = UserMessageCreateParams(message: text)
         
         if let parentMessage = parentMessage,
@@ -508,7 +507,6 @@ open class SBUBaseChannelViewModel: SBUBaseViewModel {
     ///   - text: String to be updated
     /// - Since: 1.0.9
     public func updateUserMessage(message: UserMessage, text: String) {
-        let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let messageParams = UserMessageUpdateParams(message: text)
         
         SBUGlobalCustomParams.userMessageParamsUpdateBuilder?(messageParams)


### PR DESCRIPTION
## Improvements

- Fixed intermittent vertical gaps between message cells when custom SwiftUI message views are used on iOS 26
- Fixed an empty navigation bar remaining above the header when the SDK pushes a channel view created by the `groupChannelView` builder

## Changes

- Updated dependency SDK version to the latest stable release
    - SendbirdMessageTemplate: 3.35.5